### PR TITLE
Improve behaviour for about:blank pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -34,7 +34,7 @@ browser.omnibox.onInputEntered.addListener(async (text, disposition) => {
         cookieStoreId: context.cookieStoreId,
         index: tabs[0].index
       };
-      if(tabs[0].url !== 'about:newtab') {
+      if(tabs[0].url !== 'about:newtab' && tabs[0].url !== 'about:blank') {
         tabCreateProperties.url = tabs[0].url;
       }
       browser.tabs.create(tabCreateProperties);


### PR DESCRIPTION
It allows keeping focus in omnibox when switching the container of
about:blank page.

See: #7