### PR TITLE
Prevent closing browser in case of about:home tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -34,10 +34,12 @@ browser.omnibox.onInputEntered.addListener(async (text, disposition) => {
         cookieStoreId: context.cookieStoreId,
         index: tabs[0].index
       };
-      if(tabs[0].url !== 'about:newtab' && tabs[0].url !== 'about:blank') {
+      if(tabs[0].url !== 'about:newtab' &&
+         tabs[0].url !== 'about:blank' &&
+         tabs[0].url !== 'about:home') {
         tabCreateProperties.url = tabs[0].url;
       }
-      browser.tabs.create(tabCreateProperties);
+      await browser.tabs.create(tabCreateProperties);
       browser.tabs.remove(tabs[0].id);
       break
     }


### PR DESCRIPTION
Hi, thanks for your work on Search and Switch Containers.

When starting a fresh Firefox session the first Tabs URL is set to `about:home`. When trying to switch to another container with the omnibox using `co` the Add-on will try to open a new tab with url `about:home` which will fail since it is not allowed by the API and then proceed to removing the first tab, which will close the browser since it's the only open tab.

The included change will check for `about:home` too to prevent this behaviour. I've also added an `await` to `tabs.create` to make sure that creating the tab is completed before removing the old one.