### PR TITLE
Remove unused permission: tabs.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,6 @@
   },
   "manifest_version": 2,
   "permissions": [
-    "tabs",
     "activeTab",
     "cookies",
     "contextualIdentities"


### PR DESCRIPTION
Motivation: Remove unnecessary permissions, per https://en.wikipedia.org/wiki/Principle_of_least_privilege .

After this PR, this extension will not use any permissions that Firefox considers privileged enough to bother warning users.

Tested: I removed "tabs" and this extension continues to work. Tested on Firefox 81.

This is a bit surprising, because I would have thought:
* that tab creation required "tabs" permission, but it doesn't seem to. Perhaps "tabs" permission is meant to stop extensions from seeing open tabs, and thus creating a tab doesn't require "tabs"?
* the tab deletion required "tabs" permission. Maybe that comes from `activeTab` instead?